### PR TITLE
Fixed the first digit of an integer response being skipped

### DIFF
--- a/aredis.hpp
+++ b/aredis.hpp
@@ -455,7 +455,6 @@ namespace aredis
           if (isign == is_init)
           {
             isign = is_pos;
-            break;
           }
           auto& val = current_value();
           val.values.ivalue *= 10;


### PR DESCRIPTION
When a positive integer response is returned, the first character indicates the number is positive. However, the break causes the value of the first digit not to be added to the ivalue.