### PR TITLE
Fix for Visual Studio 2017, which recognises _WIN32 instead of WIN32

### DIFF
--- a/aredis.hpp
+++ b/aredis.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #include <winsock2.h>
 #include <Windows.h>
 #include <WS2tcpip.h>


### PR DESCRIPTION
Visual Studio does not recognise WIN32, but instead uses _WIN32