### PR TITLE
Add support for the Null Array response

### DIFF
--- a/aredis.hpp
+++ b/aredis.hpp
@@ -568,6 +568,7 @@ namespace aredis
           auto& val = current_value();
           if (val.len < 0)
           {
+            res.size = 0;
             val.len = 0;
             val.type = rrt_nil;
             return parser_value_end();


### PR DESCRIPTION
Currently, the library does not yet support Null Array replies ( "*-1\r\n" ), as described here: https://redis.io/topics/protocol#resp-arrays

This is due parser_array_len not expecting '-' as the first character, and no follow up code existing if this is indeed the case.

This PR looks to fix this, and seems to work in my use case (Try for example executing:
```
WATCH a
MULTI
SET a a
EXEC
```
while setting `a` over e different connection somewhere between the `WATCH` and the `EXEC`. This would originally result in the library hanging indefinitely, while now it comes back with a null response as specified by the Redis documentation.