### PR TITLE
Add test to see if the executed statement has been queued

### DIFF
--- a/aredis.hpp
+++ b/aredis.hpp
@@ -118,6 +118,18 @@ namespace aredis
       }
       return false;
     }
+
+    inline bool is_queued()
+    {
+      if (type == rrt_string_value && len == 6)
+      {
+        if (values.svalue[0] == 'Q' && values.svalue[1] == 'U' && values.svalue[2] == 'E' && values.svalue[3] == 'U' && values.svalue[4] == 'E' && values.svalue[5] == 'D')
+        {
+          return true;
+        }
+      }
+      return false;
+    }
   };
 
   enum redis_code


### PR DESCRIPTION
If a transaction has been started using `MULTI`, responses to subsequent statements will always be `QUEUED`. It is useful to be able to check for this.